### PR TITLE
fix text wrapping

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -1,33 +1,13 @@
-.about {
-  .left {
-    margin-right: 25px;
-  }
-  .avatar {
-    border-radius: 50%;
-    display: inline-block;
-    position: relative;
-    width: 250px;
-    height: 250px;
-    overflow: hidden;
-  }
-  .right-container {
-    height: 200px;
-    position: relative;
-  }
-  .right-content {
-    margin: 0;
-    position: relative;
-    top: 50%;
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
-  }
+.avatar {
+  border-radius: 50%;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  margin-right: 5%;
 }
 
-.center-image {
-  margin: 0 auto;
-  display: block;
-}
-
-.recent-posts h4 {
-  border-bottom: thin solid #f3f3f3;
+.image-txt-container {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -12,6 +12,7 @@
 
 .site-header .site-title {
   font-size: $h2;
+  margin-top: $space-2;
 }
 
 .site-nav {

--- a/index.html
+++ b/index.html
@@ -3,16 +3,12 @@ layout: default
 title: about
 ---
 
-<div id="about-container">
-  <div class="about clearfix">
-      <div class="left">
-          <img src="/assets/images/me.jpg" alt="Mark Misener" class="avatar"/>
-      </div>
-      <div class="right-container">
-        <div class="right-content">
-          <h2>Mark Misener</h2>
-          I am a software engineer interested in traffic, ETAs, and how we move. I am currently working as a data scientist on the navigation team at <a href="https://www.mapbox.com/" target="_blank">Mapbox</a>, focused on modeling traffic speeds from anonymous sensor data.
-        </div>
-      </div>
-  </div>
+<div class="image-txt-container">
+   <img src="/assets/images/me.jpg" alt="Mark Misener" class="avatar"/>
+   <div>
+     Mark is a software engineer interested in understanding patterns in how we move. He is currently working on the navigation team at <a href="https://www.mapbox.com/" target="_blank">Mapbox</a>, focused on modeling traffic speeds from anonymous sensor data.
+     {% if site.linkedin_username %}
+      For more information about Mark's background, visit his <a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank">LinkedIn profile.</a>
+      {% endif %}
+   </div>
 </div>


### PR DESCRIPTION
At certain sizes, text would wrap and spill over the image. This PR fixes that

<img width="493" alt="Screen Shot 2021-05-02 at 4 45 05 PM" src="https://user-images.githubusercontent.com/11286381/116831719-de075080-ab65-11eb-95e5-cb74a6e7514b.png">
